### PR TITLE
Tuval/recover from nosignal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Makefile.in
 .*.sw?
+tags

--- a/src/CameraGstreamer.cpp
+++ b/src/CameraGstreamer.cpp
@@ -48,19 +48,29 @@ CameraGstreamer::CameraGstreamer( CameraId id,
 
     const unsigned bufferSize = getBufferSize( description.format, description.width*description.height );
     allocateFrameBufferPool( bufferSize );
-    for( unsigned i=0; i<description.numCustomParameters; ++i ) {
-        const char * const key = description.customParameters[i].key;
-        const char * const value = description.customParameters[i].value;
+
+    handleCustomParameters( description.customParameters, description.numCustomParameters );
+
+    init();
+}
+
+void CameraGstreamer::handleCustomParameters( const DUCustomCameraParameter * customParameters, uint8_t numCustomParameters) {
+    std::cout << "[camera "<<_cameraId<<"] Handling custom parameters. Number of parameters: " << unsigned(numCustomParameters) << std::endl;
+    for( unsigned i=0; i<numCustomParameters; ++i ) {
+        const char * const key = customParameters[i].key;
+        const char * const value = customParameters[i].value;
+        std::cout << "[camera "<<_cameraId<<"] Handling custom parameter key:value ("<<key<<":"<<value<<")" << std::endl;
         auto handler = optionHandlers.find(key);
         if( handler == optionHandlers.end() ) {
             std::ostringstream errorMsg;
-            errorMsg<<"GStreamer Camera passed unsupported custom parameter \""<<key<<"\"";
+            errorMsg<<"[ERROR] GStreamer Camera "<<_cameraId<<" passed unsupported custom parameter \""<<key<<"\"" << std::endl;
+            std::cerr << errorMsg.str();
             throw std::runtime_error( errorMsg.str() );
         }
 
         (this->*(handler->second))( key, value );
     }
-    init();
+
 }
 
 void CameraGstreamer::allocateFrameBufferPool(unsigned bufferSize) {

--- a/src/CameraGstreamer.cpp
+++ b/src/CameraGstreamer.cpp
@@ -39,6 +39,7 @@ CameraGstreamer::CameraGstreamer( CameraId id,
     _readyToUseBuffer ( -1 ),
     _framesPerSecond( framesPerSecond ),
     _noSignal( false ),
+    _gstreamPipeline( description.id ),
     _isRunning( false )
 {
     assert( _framesPerSecond > 0 );
@@ -47,7 +48,6 @@ CameraGstreamer::CameraGstreamer( CameraId id,
 
     const unsigned bufferSize = getBufferSize( description.format, description.width*description.height );
     allocateFrameBufferPool( bufferSize );
-    _gstreamPipeline = description.id;
     for( unsigned i=0; i<description.numCustomParameters; ++i ) {
         const char * const key = description.customParameters[i].key;
         const char * const value = description.customParameters[i].value;

--- a/src/CameraGstreamer.h
+++ b/src/CameraGstreamer.h
@@ -87,7 +87,7 @@ private:
     pid_t                   _threadAlignToFpsId     = -1;
     std::thread             _alignToFpsThread;
     std::string             _gstreamPipeline;
-    std::atomic<bool>       _restartPipeline;
+    std::atomic<bool>       _restartPipeline        = false;
     bool                    _loop                   = false;
     std::atomic<bool>       _isRunning;
     bool                    _trigger                = false;

--- a/src/CameraGstreamer.h
+++ b/src/CameraGstreamer.h
@@ -86,8 +86,8 @@ private:
     time_point              _lastCapturedTimestamp;
     pid_t                   _threadAlignToFpsId     = -1;
     std::thread             _alignToFpsThread;
-    std::string             _gstreamPipeline;
-    std::atomic<bool>       _restartPipeline        = false;
+    const std::string       _gstreamPipeline;
+    std::atomic<bool>       _restartPipeline        { false };
     bool                    _loop                   = false;
     std::atomic<bool>       _isRunning;
     bool                    _trigger                = false;

--- a/src/CameraGstreamer.h
+++ b/src/CameraGstreamer.h
@@ -68,6 +68,8 @@ class CameraGstreamer {
     void optionTrigger( const char *key, const char *value );
     void getPipelineValue( const char *key, const char *value );
     bool parseBoolValue( const char *key, const char *value );
+    void allocateFrameBufferPool(unsigned bufferSize);
+    void releaseBufferPool();
 
     static const std::unordered_map< std::string, void (CameraGstreamer::*)( const char *key, const char *value ) > optionHandlers;
 

--- a/src/CameraGstreamer.h
+++ b/src/CameraGstreamer.h
@@ -73,6 +73,7 @@ private:
     static bool parseBoolValue( const char *key, const char *value );
     void allocateFrameBufferPool(unsigned bufferSize);
     void releaseBufferPool();
+    void handleCustomParameters( const DUCustomCameraParameter * customParameters, uint8_t numCustomParameters);
 
     static const std::unordered_map< std::string, void (CameraGstreamer::*)( const char *key, const char *value ) > optionHandlers;
 

--- a/src/CameraGstreamer.h
+++ b/src/CameraGstreamer.h
@@ -22,6 +22,7 @@ constexpr const unsigned RING = 3;
 
 typedef std::chrono::duration<double, std::micro> DurationUS;
 using time_point = std::chrono::steady_clock::time_point;
+using microseconds = unsigned long long;
 
 class CamerasManager;
 

--- a/src/CameraGstreamer.h
+++ b/src/CameraGstreamer.h
@@ -32,7 +32,11 @@ public:
           const DUCameraDescriptor description,
           CamerasManager *manager,
           unsigned framesPerSecond );
-    virtual ~CameraGstreamer();
+    ~CameraGstreamer();
+
+    CameraGstreamer(const CameraGstreamer &) = delete;
+    CameraGstreamer& operator=(const CameraGstreamer &) = delete;
+
     void init();
     void start();
     void stop();


### PR DESCRIPTION
There are a lot of changes here, if you go over each commit separately it will be easier for you.
After 2 seconds in no-signal, the gstreamer pipeline will be re-run, and will be re-run again every 2 seconds until a frame is captured.

Also fixed some more small bugs, unreleased memory allocations + improved verbosity and readability. (see the commit messages)

Thanks,