### PR TITLE
[verbosity] Clear assert when received frame is larger than buffer

### DIFF
--- a/src/CameraGstreamer.h
+++ b/src/CameraGstreamer.h
@@ -89,6 +89,8 @@ private:
 
     static const std::unordered_map< std::string, void (CameraGstreamer::*)( const char *key, const char *value ) > optionHandlers;
 
+
+    const unsigned int      _bufferSize;
     const unsigned int      _cameraId;
     CamerasManager * const   _manager;
     std::atomic<int>        _readyToUseBuffer;


### PR DESCRIPTION
Clearer error when mis-configuring the camera-size and the pipeline's frame-size,
in the cameras.yaml.
Until now we would try to memcpy without verifying the size, and simply
receive a segmentation fault with no prior explanation.
Now there will be a clear error message followed by an assert.