### PR TITLE
[MIYAD-6151] bug fix:

### DIFF
--- a/src/CamerasManager.cpp
+++ b/src/CamerasManager.cpp
@@ -78,3 +78,8 @@ void CamerasManager::badFrame( CameraId id )
 {
     _cameraStateChanged( id, 20000, _opaq );
 }
+
+void CamerasManager::badPipeline( CameraId id )
+{
+    _cameraStateChanged( id, 10001, _opaq );
+}

--- a/src/CamerasManager.h
+++ b/src/CamerasManager.h
@@ -46,6 +46,7 @@ public:
     void goodCamera( CameraId id );
     void badCamera( CameraId id );
     void badFrame( CameraId id );
+    void badPipeline( CameraId id );
 };
 
 #endif // CAMERAS_MANAGER_H


### PR DESCRIPTION
1. Remove assert in case there is no start_timestamp.
2. Add bad pipeline state option.
3. Set bad pipeline state in case there is no no appsink.
4. Clear _startTimestampQueue when stopPipeline is called and print queue size.