### PR TITLE
[MIYAD-5466][MIYAD-6205] duCameraDisable will not stop cameras (because we don't have a mechanism to switch trigger)

### DIFF
--- a/src/camera-interface.cpp
+++ b/src/camera-interface.cpp
@@ -43,6 +43,8 @@ void duCameraEnable( CameraId id ) {
 }
 
 void duCameraDisable( CameraId id ) {
+    // MIYAD-6205: Currently we don't have a mechanism to switch trigger cameras, so we should never stop the trigger cam
+    std::cout << "[camera " << id << "] duCameraDisable called for camera. Doing nothing." << std::endl;
 }
 
 uint64_t duLibraryVersion() {


### PR DESCRIPTION
Revert "[MIYAD-5466] Add implementation to allow stopping of a running camera." This reverts commit 2dc6fb253328c732e2204212d8559bc14a9396ca.

* Breaks MIYAD-5466
* Workaround for MIYAD-6205

* duCameraDisable will no longer stop the camera. It will have no actual effect, except for logging that duCameraDisable was called for the camera.

* We currently always use the same trigger camera, even if this camera is not in the current layout. (e.g if front camera is set as trigger, then even when using a layout which only displays the cargo camera, the front camera will still be used as the trigger).
This means that we currently are never allowed to stop the trigger camera.

* This will break the MIYAD-5466 fix for the gstreamer camera lib, meaning that the Streamer will once again segfault in it's teardown (only when using the gstreamer.so).

* A proper fix for MIYAD-6205, which enables us to stop the trigger camera, and have a new trigger automatically chosen, will probably be added later.